### PR TITLE
Travis-CI: Drop Ruby 1.8.7/1.9.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
 notifications:
   email:


### PR DESCRIPTION
This is really EOL since ages and the gems don't work anymore. There is
probably more to cleanup, but this is a low hanging fruit and reduces the
test matrix. Probably a good first step.